### PR TITLE
fix(release): remove files prop from package.json

### DIFF
--- a/libs/react-components/package.json
+++ b/libs/react-components/package.json
@@ -4,9 +4,6 @@
   "type": "module",
   "main": "dist/libs/react-components/index.js",
   "types": "dist/libs/react-components/index.d.ts",
-  "files": [
-    "dist/libs/react-components"
-  ],
   "sideEffects": [
     "**/*.css"
   ]


### PR DESCRIPTION
- Remove the `files` prop from package.json as it is causing the build files to be skipped when zipped into a tar file.