### PR TITLE
feat(footer): add links of interest section

### DIFF
--- a/libs/react-components/src/lib/components/Chip/styles.module.scss
+++ b/libs/react-components/src/lib/components/Chip/styles.module.scss
@@ -6,7 +6,7 @@
   display: inline-block;
   font-family: var(--mdc-typography-subtitle1-font-family);
   font-weight: var(--mdc-typography-subtitle1-font-weight);
-  padding: 1rem 1.5rem;
+  padding: 1rem 0.75rem;
   transition: all 0.25s ease-in-out 0s;
   white-space: nowrap;
 
@@ -24,4 +24,10 @@
   border-color: var(--td-web-primary-navy);
   color: var(--cv-theme-surface-container-lowest);
   cursor: default;
+}
+
+@media screen and (min-width: 1024px) {
+  .chip {
+    padding: 1rem 1.5rem;
+  }
 }

--- a/libs/react-components/src/lib/components/Footer/Footer.stories.tsx
+++ b/libs/react-components/src/lib/components/Footer/Footer.stories.tsx
@@ -214,6 +214,23 @@ const meta = {
         href: 'https://www.teradata.com/how-we-help#tracking-consent',
       },
     ],
+    linksOfInterest: {
+      title: 'Also of interest',
+      items: [
+        {
+          label: 'Drive ROI with Trusted AI today',
+          href: 'https://www.teradata.com/platform/ai-ml',
+        },
+        {
+          label: 'Big data',
+          href: 'https://www.teradata.com/solutions/big-data',
+        },
+        {
+          label: 'Become an expert at defending your data',
+          href: 'https://www.teradata.com/insights/data-security',
+        },
+      ],
+    },
     copyright: '2024 Teradata. All Rights Reserved',
   },
 } satisfies Meta<typeof Footer>;

--- a/libs/react-components/src/lib/components/Footer/index.tsx
+++ b/libs/react-components/src/lib/components/Footer/index.tsx
@@ -52,6 +52,10 @@ interface FooterProps {
    * List of the legal links.
    */
   legalLinks?: FooterNavLink[];
+  /**
+   * Links of interest to be displayed on top of the footer.
+   */
+  linksOfInterest?: FooterLink;
 }
 
 export const FooterNavLinkList: React.FC<FooterLink> = ({ title, items }) => {
@@ -111,56 +115,80 @@ const Footer: React.FC<FooterProps> = ({
   copyright,
   socialLinks,
   legalLinks,
+  linksOfInterest,
 }) => {
   return (
-    <footer className={styles.footer}>
-      <section
-        className={`${styles.containerWide} ${styles.footerLinksWrapper}`}
-      >
-        {links &&
-          links.map((link, index) => (
-            <FooterNavLinkList
-              key={index}
-              items={link.items}
-              title={link.title}
-            />
-          ))}
-        {socialLinks && (
-          <div className={`${styles.footerLink} ${styles.socialLinksWrapper}`}>
-            <div className={styles.footerLinkTitle}>{socialLinks.title}</div>
-            <ul className={styles.socialLinksList}>
-              {socialLinks.items?.map((item, index) => (
-                <li key={index}>
-                  <IconLink
-                    iconName={item.icon}
-                    href={item.href}
-                    size={12}
-                    label={item.label}
-                  />
-                </li>
-              ))}
-            </ul>
+    <>
+      {linksOfInterest && (
+        <section className={styles.linksOfInterest}>
+          <div className={styles.linksOfInterestTitle}>
+            {linksOfInterest.title}
           </div>
-        )}
-      </section>
-      <section className={`${styles.containerWide} ${styles.copyrightWrapper}`}>
-        <div className={styles.copyrightLinks}>
-          <div className={styles.copyrightText}>&copy;{copyright}</div>
-          {legalLinks && (
-            <ul className={styles.legalLinksWrapper}>
-              {legalLinks.map((item, index) => (
-                <FooterNavLinkItem
-                  key={index}
-                  label={item.label}
+          <ul>
+            {linksOfInterest.items.map((item, index) => (
+              <li className={styles.linkOfInterest} key={index}>
+                <a
+                  className={styles.footerNavLink}
                   href={item.href}
-                  external={item.external}
-                />
-              ))}
-            </ul>
+                  target={item.external ? '_blank' : '_self'}
+                  rel="noreferrer"
+                >
+                  {item.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+      <footer className={`${styles.containerWide} ${styles.footer}`}>
+        <section className={`${styles.footerLinksWrapper}`}>
+          {links &&
+            links.map((link, index) => (
+              <FooterNavLinkList
+                key={index}
+                items={link.items}
+                title={link.title}
+              />
+            ))}
+          {socialLinks && (
+            <div
+              className={`${styles.footerLink} ${styles.socialLinksWrapper}`}
+            >
+              <div className={styles.footerLinkTitle}>{socialLinks.title}</div>
+              <ul className={styles.socialLinksList}>
+                {socialLinks.items?.map((item, index) => (
+                  <li key={index}>
+                    <IconLink
+                      iconName={item.icon}
+                      href={item.href}
+                      size={12}
+                      label={item.label}
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
-        </div>
-      </section>
-    </footer>
+        </section>
+        <section className={`${styles.copyrightWrapper}`}>
+          <div className={styles.copyrightLinks}>
+            <div className={styles.copyrightText}>&copy;{copyright}</div>
+            {legalLinks && (
+              <ul className={styles.legalLinksWrapper}>
+                {legalLinks.map((item, index) => (
+                  <FooterNavLinkItem
+                    key={index}
+                    label={item.label}
+                    href={item.href}
+                    external={item.external}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+      </footer>
+    </>
   );
 };
 

--- a/libs/react-components/src/lib/components/Footer/styles.module.scss
+++ b/libs/react-components/src/lib/components/Footer/styles.module.scss
@@ -8,23 +8,14 @@
 
 .footer {
   margin: 0;
-  padding: 20px 0 40px;
-  box-sizing: border-box;
-  background: var(--td-web-gray-25);
-  font-family: Inter, sans-serif;
-  -webkit-font-smoothing: antialiased;
-
-  ul {
-    padding: 0;
-    margin: 0;
-    list-style: none;
-  }
+  padding-bottom: 40px;
 }
 
 .footerLinksWrapper {
-  display: flex;
   align-items: flex-start;
+  display: flex;
   flex-wrap: nowrap;
+  padding-top: 20px;
 }
 
 .footerLink {
@@ -107,19 +98,77 @@
   margin: 0 0 0.5rem;
 }
 
+.footer,
+.linksOfInterest {
+  box-sizing: border-box;
+  background: var(--td-web-gray-25);
+  color: var(--td-web-primary-navy);
+  font-family: Inter, sans-serif;
+  -webkit-font-smoothing: antialiased;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+.linksOfInterest {
+  font-size: 14px;
+  line-height: 28px;
+  max-width: 1440px;
+  padding: 0.5rem;
+  text-align: center;
+}
+
+.linksOfInterestTitle {
+  font-family: Space Grotesk, sans-serif;
+  font-weight: 600;
+  margin: 0;
+}
+
+.linkOfInterest a {
+  font-size: 14px;
+}
+
 @media screen and (min-width: 768px) {
   .footer {
-    padding: 60px 0 40px;
+    padding-bottom: 40px;
+  }
+
+  .footerLinksWrapper {
+    padding-top: 60px;
   }
 
   .legalLinksWrapper .footerLinkItem {
     margin: 0;
+  }
+
+  .linksOfInterestTitle {
+    flex-basis: 140px;
+    flex-grow: 0;
+    flex-shrink: 0;
+    margin-right: 2em;
+  }
+
+  .linksOfInterest {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    text-align: left;
   }
 }
 
 @media screen and (min-width: 992px) {
   .copyrightLinks {
     margin: 1rem 0 2.625rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .linkOfInterest {
+    display: inline-block;
+    margin-right: 2em;
   }
 }
 
@@ -173,8 +222,13 @@
     margin: 2rem 0;
   }
 
-  .legalLinksWrapper .footerNavLink {
+  .legalLinksWrapper .footerNavLink,
+  .linkOfInterest a {
     text-decoration: underline;
     background-size: 0 1px;
+  }
+
+  .linksOfInterest {
+    line-height: 26px;
   }
 }


### PR DESCRIPTION
- Add a section in the footer for links of interest, to be consistent with [teradata.com](https://www.teradata.com/)
- Adjust padding of chips for smaller screens.

<img width="1442" alt="Screenshot 2024-07-19 at 10 41 23 AM" src="https://github.com/user-attachments/assets/91d5b992-bb69-4dab-8caf-eb3b3e6626a9">
<img width="810" alt="Screenshot 2024-07-19 at 10 41 42 AM" src="https://github.com/user-attachments/assets/b723de9e-a57d-4706-874a-c9c8154bc0ab">
<img width="499" alt="Screenshot 2024-07-19 at 10 41 50 AM" src="https://github.com/user-attachments/assets/b545e2e4-cc5c-41b2-b5d1-423826738405">
