### PR TITLE
fix(footer): adjust styles for footer to occupy full width

### DIFF
--- a/libs/react-components/src/lib/components/Footer/index.tsx
+++ b/libs/react-components/src/lib/components/Footer/index.tsx
@@ -140,8 +140,10 @@ const Footer: React.FC<FooterProps> = ({
           </ul>
         </section>
       )}
-      <footer className={`${styles.containerWide} ${styles.footer}`}>
-        <section className={`${styles.footerLinksWrapper}`}>
+      <footer className={`${styles.footer}`}>
+        <section
+          className={`${styles.containerWide} ${styles.footerLinksWrapper}`}
+        >
           {links &&
             links.map((link, index) => (
               <FooterNavLinkList
@@ -170,7 +172,9 @@ const Footer: React.FC<FooterProps> = ({
             </div>
           )}
         </section>
-        <section className={`${styles.copyrightWrapper}`}>
+        <section
+          className={`${styles.containerWide} ${styles.copyrightWrapper}`}
+        >
           <div className={styles.copyrightLinks}>
             <div className={styles.copyrightText}>&copy;{copyright}</div>
             {legalLinks && (

--- a/libs/react-components/src/lib/components/Footer/styles.module.scss
+++ b/libs/react-components/src/lib/components/Footer/styles.module.scss
@@ -116,7 +116,6 @@
 .linksOfInterest {
   font-size: 14px;
   line-height: 28px;
-  max-width: 1440px;
   padding: 0.5rem;
   text-align: center;
 }


### PR DESCRIPTION
#### Adjust styles to make the footer occupy full width of it's container.

**Before:**
<img width="1727" alt="Screenshot 2024-07-24 at 1 04 48 PM" src="https://github.com/user-attachments/assets/9be1392a-9885-40c2-86c6-2ac9d39bcc2f">


**After:**
<img width="1726" alt="Screenshot 2024-07-24 at 1 04 58 PM" src="https://github.com/user-attachments/assets/4291073a-f5b2-4618-9ff1-ab81acec6de5">
