### PR TITLE
feat(react): adding breadcrumb and list item components

### DIFF
--- a/libs/react-components/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/libs/react-components/src/lib/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Breadcrumb from './index';
+
+const meta = {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    items: [
+      {
+        label: 'Home',
+        link: '#',
+      },
+      {
+        label: 'Our platform',
+        link: '#',
+      },
+      {
+        label: 'Breadcrumb item 3',
+        link: '#',
+      },
+    ],
+  },
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/libs/react-components/src/lib/components/Breadcrumb/index.tsx
+++ b/libs/react-components/src/lib/components/Breadcrumb/index.tsx
@@ -1,0 +1,24 @@
+import styles from './styles.module.scss';
+
+interface BreadcrumbProps {
+  /**
+   * The items of the breadcrumb
+   */
+  items: { label: string; link: string }[];
+}
+
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ items }) => {
+  return (
+      <nav className={styles.breadcrumb}>
+        <ul>
+            {items.map((item, index) => (
+                <li key={index}>
+                    <a href={item.link}>{item.label}</a>
+                </li>
+            ))}
+        </ul>
+      </nav>
+  );
+};
+
+export default Breadcrumb;

--- a/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
+++ b/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
@@ -1,0 +1,48 @@
+
+
+.breadcrumb {
+    font-size: .75rem;
+    line-height: 1rem;
+    
+    ul {
+        list-style: none;
+        display: inline;
+        padding: 0;
+        margin: 0;
+        li {
+            display: inline-flex;
+            align-items: center;
+
+            a {
+                text-decoration: none;
+                color: inherit;
+                font-family: Inter;
+                font-size: 12px;
+                font-style: normal;
+                font-weight: 400;
+                line-height: 20px; 
+                display: inline-flex;
+                align-items: center;
+                color: #00233c;
+                transition: color 250ms;
+
+                &:after {
+                    content: 'chevron_right';
+                    font-family: 'Material Symbols Outlined';
+                    margin:0 .25rem;
+                    color: #00233c;
+
+                }
+                &:hover {
+                    color: #ff5f02;
+                }
+            }
+
+            &:last-child a {
+                &:after {
+                    display: none;
+                }
+            }
+        }
+    }
+}

--- a/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
+++ b/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
@@ -30,11 +30,11 @@
                     content: 'chevron_right';
                     font-family: 'Material Symbols Outlined';
                     margin:0 .25rem;
-                    color: #00233c;
+                    color: var(--td-web-primary-navy);
 
                 }
                 &:hover {
-                    color: #ff5f02;
+                    color: var(--cv-theme-tertiary);
                 }
             }
 

--- a/libs/react-components/src/lib/components/ListItem/ListItem.stories.tsx
+++ b/libs/react-components/src/lib/components/ListItem/ListItem.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ListItem from './index';
+
+const meta = {
+  title: 'Components/ListItem',
+  component: ListItem,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    label: 'List item label',
+    content: (
+      <>
+        <p>Test content of the card</p>
+      </>
+    ),
+  },
+} satisfies Meta<typeof ListItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/libs/react-components/src/lib/components/ListItem/index.tsx
+++ b/libs/react-components/src/lib/components/ListItem/index.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, useState } from 'react';
+import styles from './styles.module.scss';
+
+interface ListItemProps {
+  /**
+   * The label of the list item
+   */
+  label: string;
+
+  /**
+   * Whether the list item is active or not
+   */
+  active?: boolean;
+
+  /**
+   * The content of the list item
+   */
+  content: ReactNode;
+}
+
+const ListItem: React.FC<ListItemProps> = ({ label, active, content }) => {
+  const [isActive, setActive] = useState(active);
+  const hasContent = content !== undefined;
+  const contentActiveStyles = isActive ? styles.active : '';
+  const activeStyles = isActive ? styles.active : '';
+
+  const toggleActive = () => {
+    setActive(!isActive);
+  };
+  return (
+    <>
+      <div className={`${styles.listItem} ${activeStyles}`} onClick={toggleActive}>
+        { hasContent && <button aria-label={`Expand nav category '${label}'`} aria-expanded="false" type="button" className={styles.caret}></button>}
+        <span>{label}</span>
+      </div>
+      {content && <div className={`${styles.content} ${contentActiveStyles}`}>{content}</div>}
+    </>
+  );
+};
+
+export default ListItem;

--- a/libs/react-components/src/lib/components/ListItem/styles.module.scss
+++ b/libs/react-components/src/lib/components/ListItem/styles.module.scss
@@ -1,0 +1,64 @@
+.listItem {
+    font-family: var(--mdc-typography-subtitle1-font-family);
+    font-weight: var(--mdc-typography-subtitle1-font-weight);
+    font-size: 14px;
+    letter-spacing: .25px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 20px;
+    border-radius: var(--mdc-list-side-padding, 16px);
+    color: --cv-theme-on-secondary-container;
+    align-items: center;
+    display: flex;
+    transition: background 200ms cubic-bezier(0.08,0.52,0.52,1);
+    cursor: pointer;
+
+    span {
+        padding: 4px 12px;
+    }
+
+    &:hover {
+        background-color: #1e1d1e14;
+        text-decoration: none;
+    }
+
+    &.active {
+        color: #171a2c;
+        background-color: #dfe1f9;
+    }
+}
+
+
+.content {
+    height: 0;
+    overflow: hidden;
+    transition: height 200ms cubic-bezier(0.08,0.52,0.52,1);
+    &.active {
+        height: auto;
+    }
+}
+
+.caret {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    padding: 0;
+
+    &::before {
+        background:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTEwIDE3IDUtNS01LTV2MTBaIiBmaWxsPSIjNUM1QjVGIi8+PC9zdmc+)  50%/1.5rem 1.5rem;
+        height: 1.25rem;
+        transition: transform 200ms linear;
+        width: 1.25rem;
+        margin-left: calc(0.75rem/2);
+        content: "";
+        filter: none;
+        transform: rotate(0);
+        display: block;
+    }
+
+    .active &::before {
+        transform: rotate(90deg);
+    }
+}

--- a/libs/react-components/src/lib/components/ListItem/styles.module.scss
+++ b/libs/react-components/src/lib/components/ListItem/styles.module.scss
@@ -7,7 +7,7 @@
     font-weight: 400;
     line-height: 20px;
     border-radius: var(--mdc-list-side-padding, 16px);
-    color: --cv-theme-on-secondary-container;
+    color: var(--cv-theme-on-secondary-container);
     align-items: center;
     display: flex;
     transition: background 200ms cubic-bezier(0.08,0.52,0.52,1);

--- a/libs/react-components/src/lib/index.ts
+++ b/libs/react-components/src/lib/index.ts
@@ -1,5 +1,6 @@
 import './styles.scss';
 import Banner from './components/Banner';
+import Breadcrumb from './components/Breadcrumb';
 import Button from './components/Button';
 import Card from './components/Card';
 import CodeSnippet from './components/CodeSnippet';
@@ -17,6 +18,7 @@ import LanguageDropdown, {
   Language,
   MenuPosition,
 } from './components/LanguageDropdown';
+import ListItem from './components/ListItem';
 import NavItem, { NavListItem } from './components/NavItem';
 import Chip from './components/Chip';
 import ChipSet from './components/ChipSet';
@@ -25,6 +27,7 @@ import Typography from './components/Typography';
 
 export {
   Banner,
+  Breadcrumb,
   Button,
   Card,
   Chip,
@@ -38,6 +41,7 @@ export {
   IconButton,
   IconLink,
   LanguageDropdown,
+  ListItem,
   NavItem,
   Tab,
   TabBar,


### PR DESCRIPTION
Adding basic component styles for Breadcrumb and List Item component

**This is to support the Headless CMS POC**

### Screenshots
![Screenshot 2024-07-25 at 12 21 08 PM](https://github.com/user-attachments/assets/b67dc5ef-8bbf-42b8-bb77-adac654790fb)

![Screenshot 2024-07-25 at 12 20 39 PM](https://github.com/user-attachments/assets/8465c4e1-60fb-44b3-ae7e-5763c0857817)
