### PR TITLE
fix(links): open external links in new tab

### DIFF
--- a/libs/react-components/src/lib/components/Card/index.tsx
+++ b/libs/react-components/src/lib/components/Card/index.tsx
@@ -33,13 +33,18 @@ const Card: React.FC<CardProps> = ({
   imageAltText,
   imageDirection = 'left',
   imageSrc,
-  imageWidth = '35%',
+  imageWidth = '350px',
   title,
 }) => {
   return (
     <div className={`${styles.card} ${styles[imageDirection]}`}>
       {imageSrc && (
-        <div className={styles.cardImage} style={{ flex: `0 0 ${imageWidth}` }}>
+        <div
+          className={styles.cardImage}
+          style={
+            { '--td-web-card-img-width': imageWidth } as React.CSSProperties
+          }
+        >
           <img src={imageSrc} alt={imageAltText} />
         </div>
       )}

--- a/libs/react-components/src/lib/components/Card/styles.module.scss
+++ b/libs/react-components/src/lib/components/Card/styles.module.scss
@@ -73,7 +73,7 @@
 }
 
 .cardImage {
-  flex: 0 0 350px;
+  flex: 0 0 var(--td-web-card-img-width);
 
   img {
     display: block;

--- a/libs/react-components/src/lib/components/Footer/index.tsx
+++ b/libs/react-components/src/lib/components/Footer/index.tsx
@@ -96,7 +96,12 @@ export const FooterNavLinkItem: React.FC<FooterNavLink> = ({
 }) => {
   return (
     <li className={styles.footerLinkItem}>
-      <a href={href} className={styles.footerNavLink}>
+      <a
+        href={href}
+        className={styles.footerNavLink}
+        target={external ? '_blank' : '_self'}
+        rel="noreferrer"
+      >
         {label}
         {external && (
           <img

--- a/libs/react-components/src/lib/components/Footer/styles.module.scss
+++ b/libs/react-components/src/lib/components/Footer/styles.module.scss
@@ -66,7 +66,6 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1rem 0.75rem;
-  padding-top: 1rem;
 }
 
 .legalLinksWrapper {

--- a/libs/react-components/src/lib/components/Footer/styles.module.scss
+++ b/libs/react-components/src/lib/components/Footer/styles.module.scss
@@ -108,6 +108,12 @@
   color: var(--td-web-primary-navy);
   font-family: Inter, sans-serif;
   -webkit-font-smoothing: antialiased;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .linksOfInterest {
@@ -125,12 +131,6 @@
 
 .linkOfInterest a {
   font-size: 14px;
-}
-
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
 }
 
 @media screen and (min-width: 768px) {

--- a/libs/react-components/src/lib/components/NavItem/index.tsx
+++ b/libs/react-components/src/lib/components/NavItem/index.tsx
@@ -53,6 +53,7 @@ const NavItem: React.FC<NavItemProps> = ({
   href,
   nestedNavItems = [],
   label,
+  external,
   onClick,
   onMenuChange,
 }) => {
@@ -120,7 +121,8 @@ const NavItem: React.FC<NavItemProps> = ({
                   >
                     <a
                       href={item.href}
-                      target="_self"
+                      target={item.external ? '_blank' : '_self'}
+                      rel="noreferrer"
                       className={`${item.external ? styles.externalLink : ''} ${
                         item.active ? styles.active : ''
                       }`}
@@ -143,7 +145,8 @@ const NavItem: React.FC<NavItemProps> = ({
       ) : (
         <a
           href={href}
-          target="_self" // TODO: remove this
+          target={external ? '_blank' : '_self'}
+          rel="noreferrer"
           className={`${styles.navItemLink} ${active ? styles.active : ''}`}
           onClick={handleClick}
         >

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.9.0",
   "license": "MIT",
   "scripts": {
-    "semantic-release": "semantic-release --branches main",
     "build-storybook": "nx run react-components:build-storybook",
     "format:check": "nx format",
-    "release:prepare": "npx nx run-many --target=build --all && node ./scripts/version-placeholder ./dist"
+    "release:prepare": "npx nx run-many --target=build --all && node ./scripts/version-placeholder ./dist",
+    "semantic-release": "semantic-release --branches main",
+    "storybook": "nx run react-components:storybook"
   },
   "dependencies": {
     "react": "18.3.1",


### PR DESCRIPTION
- Open external links in the footer and header in a new tab
- Use a css variable to set card image width
- Add an npm script command to run storybook
- Fix for leaking list styles

#### External links
<img width="1201" alt="Screenshot 2024-08-13 at 9 10 55 AM" src="https://github.com/user-attachments/assets/edaf6928-c354-4120-b885-774b0565226c">

#### Card Image
<img width="1112" alt="Screenshot 2024-08-13 at 9 11 17 AM" src="https://github.com/user-attachments/assets/d1a7b5c0-e031-4668-bcf7-854de0ec2f4e">
