### PR TITLE
feat(language switcher) adds an optional text justified to the right

### DIFF
--- a/libs/react-components/src/lib/components/Header/Header.stories.tsx
+++ b/libs/react-components/src/lib/components/Header/Header.stories.tsx
@@ -93,14 +93,24 @@ const meta = {
         type: 'button',
       },
     ],
-    announcementContent: {
-      icon: <Icon className="fa-regular fa-bell" />,
-      text: 'Get started with Teradata today.',
-      link: {
-        url: 'https://www.teradata.com/getting-started/demos/clearscape-analytics',
-        label: 'Start free demo',
-      },
-    },
+    announcementContent: (
+      <div>
+        <Icon className="fa-regular fa-bell" style={{ marginRight: '8px' }} />
+        <span>Important Announcement: </span>
+        <a
+          href="https://www.teradata.com"
+          style={{
+            marginLeft: '4px',
+            color: '#007bff',
+            textDecoration: 'underline',
+          }}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Start free demo
+        </a>
+      </div>
+    ),
   },
 } satisfies Meta<typeof Header>;
 

--- a/libs/react-components/src/lib/components/Header/Header.stories.tsx
+++ b/libs/react-components/src/lib/components/Header/Header.stories.tsx
@@ -93,6 +93,14 @@ const meta = {
         type: 'button',
       },
     ],
+    announcementContent: {
+      icon: <Icon className="fa-regular fa-bell" />,
+      text: 'Get started with Teradata today.',
+      link: {
+        url: 'https://www.teradata.com/getting-started/demos/clearscape-analytics',
+        label: 'Start free demo',
+      },
+    },
   },
 } satisfies Meta<typeof Header>;
 

--- a/libs/react-components/src/lib/components/Header/index.tsx
+++ b/libs/react-components/src/lib/components/Header/index.tsx
@@ -57,11 +57,7 @@ interface HeaderProps {
   /**
    * Announcement content to be displayed in the header
    */
-  announcementContent?: {
-    icon: JSX.Element;
-    text: string;
-    link?: { url: string; label: string };
-  };
+  announcementContent?: React.ReactNode;
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -152,23 +148,12 @@ const Header: React.FC<HeaderProps> = ({
       >
         {/* Header utility bar with the language switcher begins */}
         <section className={styles.headerUtility}>
-          <div className={styles.containerWide}>
-            {announcementContent && (
-              <div className={styles.announcement}>
-                {announcementContent.icon && announcementContent.icon}
-                <span className={styles.text}>{announcementContent.text}</span>
-                {announcementContent.link && (
-                  <a
-                    href={announcementContent.link.url}
-                    className={styles.link}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {announcementContent.link.label}
-                  </a>
-                )}
-              </div>
-            )}
+          <div
+            className={`${styles.containerWide} ${
+              announcementContent ? styles.containerWideWithAnnouncment : ''
+            }`}
+          >
+            {announcementContent && announcementContent}
             <ul className={styles.headerUtilityNav}>
               <li>
                 <a href="https://www.teradata.com/" target="_self">

--- a/libs/react-components/src/lib/components/Header/index.tsx
+++ b/libs/react-components/src/lib/components/Header/index.tsx
@@ -54,6 +54,14 @@ interface HeaderProps {
    * Secondary menu content for mobile view
    */
   secondaryMenu?: { menuElement: JSX.Element; title: string };
+  /**
+   * Announcement content to be displayed in the header
+   */
+  announcementContent?: {
+    icon: JSX.Element;
+    text: string;
+    link?: { url: string; label: string };
+  };
 }
 
 const Header: React.FC<HeaderProps> = ({
@@ -65,6 +73,7 @@ const Header: React.FC<HeaderProps> = ({
   onLanguageChange,
   selectedLanguage,
   secondaryMenu,
+  announcementContent,
 }) => {
   const [activeNavItem, setActiveNavItem] = useState<number | null>(
     navItems.findIndex((item) => item.active)
@@ -144,6 +153,22 @@ const Header: React.FC<HeaderProps> = ({
         {/* Header utility bar with the language switcher begins */}
         <section className={styles.headerUtility}>
           <div className={styles.containerWide}>
+            {announcementContent && (
+              <div className={styles.announcement}>
+                {announcementContent.icon && announcementContent.icon}
+                <span className={styles.text}>{announcementContent.text}</span>
+                {announcementContent.link && (
+                  <a
+                    href={announcementContent.link.url}
+                    className={styles.link}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {announcementContent.link.label}
+                  </a>
+                )}
+              </div>
+            )}
             <ul className={styles.headerUtilityNav}>
               <li>
                 <a href="https://www.teradata.com/" target="_self">

--- a/libs/react-components/src/lib/components/Header/styles.module.scss
+++ b/libs/react-components/src/lib/components/Header/styles.module.scss
@@ -35,7 +35,7 @@ body {
 
 .headerUtility .containerWide {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   box-sizing: border-box;
   align-items: center;
 }
@@ -65,6 +65,18 @@ body {
 .headerUtility a:hover {
   background-size: 100% 1px;
   text-decoration: none;
+}
+
+.headerUtility .announcement i {
+  margin-right: 8px;
+}
+
+.headerUtility .announcement {
+  font-size: 16px !important;
+}
+
+.headerUtility .announcement a {
+  margin-left: 8px;
 }
 
 .headerNavWrapper {

--- a/libs/react-components/src/lib/components/Header/styles.module.scss
+++ b/libs/react-components/src/lib/components/Header/styles.module.scss
@@ -41,10 +41,7 @@ body {
 }
 
 .headerUtility .containerWideWithAnnouncment {
-  display: flex;
   justify-content: space-between;
-  box-sizing: border-box;
-  align-items: center;
 }
 
 .headerUtility ul {

--- a/libs/react-components/src/lib/components/Header/styles.module.scss
+++ b/libs/react-components/src/lib/components/Header/styles.module.scss
@@ -35,6 +35,13 @@ body {
 
 .headerUtility .containerWide {
   display: flex;
+  justify-content: flex-end;
+  box-sizing: border-box;
+  align-items: center;
+}
+
+.headerUtility .containerWideWithAnnouncment {
+  display: flex;
   justify-content: space-between;
   box-sizing: border-box;
   align-items: center;
@@ -65,18 +72,6 @@ body {
 .headerUtility a:hover {
   background-size: 100% 1px;
   text-decoration: none;
-}
-
-.headerUtility .announcement i {
-  margin-right: 8px;
-}
-
-.headerUtility .announcement {
-  font-size: 16px !important;
-}
-
-.headerUtility .announcement a {
-  margin-left: 8px;
 }
 
 .headerNavWrapper {


### PR DESCRIPTION
## Description

Adds an optional text justified to the left to display messages like the Start free demo.

### What's included?

An enhancement to the Header component

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [ ] `npm run start`
- [ ] then this
- [ ] finally this

#### General Tests for Every PR

- [ ] `npm run start` still works.
- [ ] `npm run lint` passes.
- [ ] `npm test` passes and code coverage is not lower.
- [ ] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
