### PR TITLE
fix(styles): change rem values to px values

### DIFF
--- a/libs/react-components/src/lib/_mixins.scss
+++ b/libs/react-components/src/lib/_mixins.scss
@@ -1,6 +1,6 @@
 @mixin container-wide() {
   .containerWide {
-    padding: 0 1.5rem;
+    padding: 0 24px;
     margin: auto;
     max-width: 1440px;
     box-sizing: border-box;
@@ -8,13 +8,13 @@
 
   @media screen and (min-width: 768px) {
     .containerWide {
-      padding: 0 2.5rem;
+      padding: 0 40px;
     }
   }
 
   @media screen and (min-width: 1025px) {
     .containerWide {
-      padding: 0 6.625rem;
+      padding: 0 106px;
       width: 100%;
     }
   }

--- a/libs/react-components/src/lib/components/Banner/styles.module.scss
+++ b/libs/react-components/src/lib/components/Banner/styles.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column-reverse;
   font-family: var(--mdc-typography-headline5-font-family);
-  gap: 2rem;
+  gap: 32px;
   justify-content: space-between;
   margin: 0 auto;
   max-width: 1440px;
@@ -13,7 +13,7 @@
 }
 
 .bannerContent {
-  margin-top: 1rem;
+  margin-top: 16px;
 }
 
 .bannerInfo,

--- a/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
+++ b/libs/react-components/src/lib/components/Breadcrumb/styles.module.scss
@@ -1,6 +1,6 @@
 .breadcrumb {
-  font-size: 0.75rem;
-  line-height: 1rem;
+  font-size: 12px;
+  line-height: 16px;
 
   ul {
     list-style: none;
@@ -27,7 +27,7 @@
         &:after {
           content: 'chevron_right';
           font-family: 'Material Symbols Outlined';
-          margin: 0 0.25rem;
+          margin: 0 4px;
           color: var(--td-web-primary-navy);
         }
         &:hover {

--- a/libs/react-components/src/lib/components/Button/styles.module.css
+++ b/libs/react-components/src/lib/components/Button/styles.module.css
@@ -3,7 +3,7 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 12px;
   min-width: 0;
   margin-bottom: 0;
   padding: 12px 16px;
@@ -11,8 +11,8 @@
   border-radius: 12px;
   background: var(--td-web-primary-navy);
   font-weight: 600;
-  font-size: 1rem;
-  line-height: 1.5rem;
+  font-size: 16px;
+  line-height: 24px;
   color: var(--cv-theme-surface-container-lowest);
   text-align: center;
   text-decoration: none;

--- a/libs/react-components/src/lib/components/Card/styles.module.scss
+++ b/libs/react-components/src/lib/components/Card/styles.module.scss
@@ -29,7 +29,7 @@
   color: var(--td-web-primary-navy, #00233c);
   /* Desktop/H3 */
   font-family: Inter;
-  font-size: 1.5rem;
+  font-size: 24px;
   font-style: normal;
   font-weight: 600;
   line-height: 34px; /* 141.667% */
@@ -84,7 +84,7 @@
 
 .contentWrapper {
   flex: 1;
-  padding: 1.5rem;
+  padding: 24px;
 }
 
 @media screen and (max-width: 750px) {

--- a/libs/react-components/src/lib/components/Chip/styles.module.scss
+++ b/libs/react-components/src/lib/components/Chip/styles.module.scss
@@ -6,7 +6,7 @@
   display: inline-block;
   font-family: var(--mdc-typography-subtitle1-font-family);
   font-weight: var(--mdc-typography-subtitle1-font-weight);
-  padding: 1rem 0.75rem;
+  padding: 16px 12px;
   transition: all 0.25s ease-in-out 0s;
   white-space: nowrap;
 
@@ -28,6 +28,6 @@
 
 @media screen and (min-width: 1024px) {
   .chip {
-    padding: 1rem 1.5rem;
+    padding: 16px 24px;
   }
 }

--- a/libs/react-components/src/lib/components/ChipSet/styles.module.scss
+++ b/libs/react-components/src/lib/components/ChipSet/styles.module.scss
@@ -1,5 +1,5 @@
 .chipSet {
   align-items: center;
   display: flex;
-  gap: 1rem;
+  gap: 16px;
 }

--- a/libs/react-components/src/lib/components/CodeSnippet/styles.module.scss
+++ b/libs/react-components/src/lib/components/CodeSnippet/styles.module.scss
@@ -5,12 +5,12 @@
 .copyButton {
   opacity: 0;
   position: absolute;
-  top: 2.375rem;
+  top: 38px;
   transition: opacity 0.25s ease-out;
-  right: 0.285rem;
+  right: 5px;
 
-  --mdc-icon-button-size: 2.5rem;
-  --mdc-icon-size: 1.25rem;
+  --mdc-icon-button-size: 40px;
+  --mdc-icon-size: 20px;
 }
 
 .codeSnippet {
@@ -25,5 +25,5 @@
 }
 
 .headerHidden .copyButton {
-  top: 0.325rem;
+  top: 5px;
 }

--- a/libs/react-components/src/lib/components/DropdownMenu/styles.module.scss
+++ b/libs/react-components/src/lib/components/DropdownMenu/styles.module.scss
@@ -31,13 +31,13 @@
   margin-top: 5px;
   list-style: none;
   background-color: transparent;
-  padding: 0 1.5rem;
+  padding: 0 24px;
 }
 
 .dropdownMenuItem {
   list-style: none;
-  font-size: 0.9375rem;
-  line-height: 1.5rem;
+  font-size: 15px;
+  line-height: 24px;
   font-weight: 600;
   color: var(--td-web-primary-navy);
   position: relative;
@@ -50,7 +50,7 @@
     border: none;
     font-weight: 400;
     font-size: 15px;
-    padding: 0.75rem 0;
+    padding: 12px 0;
     transition: color 0.3s;
   }
 
@@ -60,7 +60,7 @@
     display: inline-flex;
 
     img {
-      padding-left: 0.25rem;
+      padding-left: 4px;
       margin-top: 2px;
     }
 
@@ -70,7 +70,7 @@
   }
 
   .dropdownMenu {
-    padding: 0 0.75rem;
+    padding: 0 12px;
   }
 }
 
@@ -81,5 +81,5 @@
 }
 
 .externalLinkImg {
-  width: 1rem;
+  width: 16px;
 }

--- a/libs/react-components/src/lib/components/Footer/styles.module.scss
+++ b/libs/react-components/src/lib/components/Footer/styles.module.scss
@@ -18,7 +18,7 @@
 }
 
 .footerLink {
-  padding: 0.5rem;
+  padding: 8px;
   flex: 1 0 0;
 }
 
@@ -32,7 +32,7 @@
 }
 
 .socialLinksWrapper .footerLinkTitle {
-  padding-bottom: 1rem;
+  padding-bottom: 16px;
 }
 
 .footerLinkItem {
@@ -44,7 +44,7 @@
   color: var(--td-web-primary-navy);
   font-weight: 400;
   font-size: 15px;
-  line-height: 1.5rem;
+  line-height: 24px;
   background-image: linear-gradient(
     var(--td-web-primary-navy),
     var(--td-web-primary-navy)
@@ -65,18 +65,18 @@
 .socialLinksList {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem 0.75rem;
+  gap: 16px 12px;
 }
 
 .legalLinksWrapper {
   display: flex;
   flex-wrap: wrap;
-  gap: 0 1.5rem;
+  gap: 0 24px;
 }
 
 .copyrightWrapper {
   align-items: center;
-  font-size: 0.875rem;
+  font-size: 14px;
   margin: 0 auto;
 }
 
@@ -90,7 +90,7 @@
 }
 
 .copyrightText {
-  margin-bottom: 1.5rem;
+  margin-bottom: 24px;
 }
 
 .externalIconImg {
@@ -98,7 +98,7 @@
 }
 
 .legalLinksWrapper .footerLinkItem {
-  margin: 0 0 0.5rem;
+  margin: 0 0 8px;
 }
 
 .footer,
@@ -119,7 +119,7 @@
 .linksOfInterest {
   font-size: 14px;
   line-height: 28px;
-  padding: 0.5rem;
+  padding: 8px;
   text-align: center;
 }
 
@@ -159,14 +159,14 @@
 
 @media screen and (min-width: 992px) {
   .copyrightLinks {
-    margin: 1rem 0 2.625rem;
+    margin: 16px 0 42px;
   }
 }
 
 @media screen and (min-width: 1024px) {
   .linkOfInterest {
     display: inline-block;
-    margin-right: 2em;
+    margin-right: 32px;
   }
 }
 
@@ -192,8 +192,8 @@
 
     .footerLinkTitle {
       pointer-events: all;
-      font-size: 1rem;
-      padding: 1rem 0;
+      font-size: 16px;
+      padding: 16px 0;
       display: flex;
       align-items: center;
       cursor: pointer;

--- a/libs/react-components/src/lib/components/Header/styles.module.scss
+++ b/libs/react-components/src/lib/components/Header/styles.module.scss
@@ -26,8 +26,8 @@ body {
 .headerUtility {
   background: var(--td-web-gray-25);
   color: var(--td-web-primary-navy);
-  font-size: 0.75rem;
-  line-height: 1rem;
+  font-size: 12px;
+  line-height: 16px;
   min-height: 28px;
   align-items: center;
   display: none;
@@ -122,7 +122,7 @@ body {
   align-items: center;
   padding: 0 20px;
   width: 100%;
-  height: 1.875rem;
+  height: 30px;
 }
 
 .headerNavActions {
@@ -132,7 +132,7 @@ body {
 }
 
 .headerNavActionItem {
-  margin-left: 1.5rem;
+  margin-left: 24px;
 }
 
 .headerNavLogo {
@@ -149,8 +149,8 @@ body {
 
 .headerNavVDivider {
   padding: 0 0.5px;
-  margin: 0 0.875rem;
-  height: 0.9375rem;
+  margin: 0 14px;
+  height: 15px;
   background-color: #5e7484;
 }
 
@@ -167,7 +167,7 @@ body {
   -webkit-font-smoothing: antialiased;
   line-height: 26px;
   box-sizing: border-box;
-  padding: 1rem 1.5rem;
+  padding: 16px 24px;
 }
 
 .headerNavMobileWrapper {
@@ -204,7 +204,7 @@ body {
 
   li {
     height: 24px;
-    padding-left: 1.25rem;
+    padding-left: 20px;
   }
 }
 
@@ -223,8 +223,8 @@ body {
 }
 
 .headerNavMobileFooter ul {
-  margin: 1em 0;
-  padding: 0 1.5rem;
+  margin: 16px 0;
+  padding: 0 24px;
   display: flex;
   align-items: center;
 }
@@ -232,7 +232,7 @@ body {
 .headerNavMobileFooter a {
   text-decoration: none;
   color: var(--td-web-gray-700);
-  font-size: 0.925rem;
+  font-size: 15px;
   font-weight: 700;
 }
 
@@ -241,15 +241,15 @@ body {
 }
 
 .headerNavMobileActions {
-  padding: 0 1.5rem;
+  padding: 0 24px;
 
   li {
-    margin: 1.5rem 0;
+    margin: 24px 0;
   }
 }
 
 .headerNavMobileSecondaryMenu {
-  padding-top: 1.5rem;
+  padding-top: 24px;
   padding-left: 2px;
 
   .show {
@@ -266,10 +266,10 @@ body {
   align-items: center;
   border-bottom: 1px solid var(--td-web-gray-100);
   justify-content: space-between;
-  padding: 1rem;
+  padding: 16px;
 
   h3 {
-    font-size: 1rem;
+    font-size: 16px;
     font-weight: 600;
     margin: 0;
   }
@@ -280,14 +280,14 @@ body {
 }
 
 .sidenavContent {
-  padding: 1rem;
+  padding: 16px;
   overflow: auto;
   height: 100%;
 }
 
 @media screen and (min-width: 768px) and (max-width: 1024px) {
   .headerNavMobile nav {
-    padding: 1rem 2.5rem;
+    padding: 16px 40px;
   }
 }
 

--- a/libs/react-components/src/lib/components/LanguageDropdown/styles.module.scss
+++ b/libs/react-components/src/lib/components/LanguageDropdown/styles.module.scss
@@ -6,14 +6,14 @@
 .languageSelectorToggle {
   align-items: center;
   display: flex;
-  padding: 0 1.2rem 0 0;
+  padding: 0 20px 0 0;
   position: relative;
   transition: 0.25s;
   width: auto;
   z-index: 1;
   border: none;
   background: transparent;
-  font-size: 0.75rem;
+  font-size: 12px;
   cursor: pointer;
 
   &:after {
@@ -42,9 +42,9 @@
   overflow: auto;
   position: absolute;
   right: 0;
-  font-size: 0.9375rem;
+  font-size: 15px;
   z-index: 1;
-  top: 2.25rem;
+  top: 36px;
   visibility: hidden;
 }
 
@@ -52,7 +52,7 @@
   background: transparent;
   cursor: pointer;
   padding: 8px 0;
-  font-size: 0.9375rem;
+  font-size: 15px;
   letter-spacing: 0;
   text-align: right;
 
@@ -79,7 +79,7 @@
 
     &.top {
       top: auto;
-      bottom: 2rem;
+      bottom: 32px;
     }
   }
 }

--- a/libs/react-components/src/lib/components/ListItem/styles.module.scss
+++ b/libs/react-components/src/lib/components/ListItem/styles.module.scss
@@ -47,11 +47,11 @@
 
   &::before {
     background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTEwIDE3IDUtNS01LTV2MTBaIiBmaWxsPSIjNUM1QjVGIi8+PC9zdmc+)
-      50%/1.5rem 1.5rem;
-    height: 1.25rem;
+      50%/24px 24px;
+    height: 20px;
     transition: transform 200ms linear;
-    width: 1.25rem;
-    margin-left: calc(0.75rem / 2);
+    width: 20px;
+    margin-left: 6px;
     content: '';
     filter: none;
     transform: rotate(0);

--- a/libs/react-components/src/lib/components/NavItem/styles.module.scss
+++ b/libs/react-components/src/lib/components/NavItem/styles.module.scss
@@ -1,6 +1,6 @@
 .navItemLink {
-  font-size: 0.9375rem;
-  line-height: 1.25rem;
+  font-size: 15px;
+  line-height: 20px;
   font-weight: 600;
   color: var(--td-web-primary-navy);
   position: relative;
@@ -8,7 +8,7 @@
   white-space: nowrap;
   text-decoration: none;
   transition: 0.25s;
-  padding: 0 0.75rem;
+  padding: 0 12px;
   cursor: pointer;
 
   &:hover {
@@ -24,7 +24,7 @@
   height: 2px;
   bottom: -8px;
   background: transparent;
-  width: 3rem;
+  width: 48px;
   left: 50%;
   transform: translateX(-50%);
   transition: all 0.1s ease;
@@ -37,7 +37,7 @@
 
 .navItemMenu {
   position: absolute;
-  top: 5rem;
+  top: 80px;
   background: var(--cv-theme-surface-container-lowest);
   transform: translateX(-32%);
   transition: all 0.25s ease-in-out 0s;
@@ -46,7 +46,7 @@
   width: 320px;
 
   ul {
-    padding: 2rem 1.5rem 1.25rem;
+    padding: 32px 24px 20px;
     li {
       list-style: none;
     }
@@ -74,5 +74,5 @@
 }
 
 .externalLinkImg {
-  width: 1rem;
+  width: 16px;
 }


### PR DESCRIPTION
## Description

<!-- Talk about the great work you've done! -->
Styles with `rem` or `em` values appear inconsistent in different apps based on the base font size of the apps.

### What's included?

<!-- List features included in this PR -->

- Replace `rem`, `em` values with `px` values to maintain consistency.

#### Test Steps

<!-- Add instructions on how to test your changes -->

- [x] `npm run storybook`
- [x] verify all components work and look consistent

#### General Tests for Every PR

- [x] `npm run start` still works.
- [x] `npm run lint` passes.
- [x] `npm test` passes and code coverage is not lower.
- [x] `npm run build` still works.

##### Screenshots or link to StackBlitz/Plunker
<img width="1715" alt="Screenshot 2024-09-26 at 11 45 35 AM" src="https://github.com/user-attachments/assets/fe08ce00-590a-4c4b-aaee-289178feb1fc">
